### PR TITLE
fix AppServiceBridgeSample_C++ x64 build

### DIFF
--- a/Samples/AppServiceBridgeSample_C++/cs/UWP/UWP.csproj
+++ b/Samples/AppServiceBridgeSample_C++/cs/UWP/UWP.csproj
@@ -152,8 +152,7 @@
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /y /s "$(SolutionDir)$(ConfigurationName)\Win32Process_CPP.exe" "$(SolutionDir)\UWP\bin\x64\$(ConfigurationName)\AppX\"
-xcopy /y /s "$(SolutionDir)$(ConfigurationName)\Win32Process_CPP.exe" "$(SolutionDir)\UWP\bin\x86\$(ConfigurationName)\AppX\"</PostBuildEvent>
+    <PostBuildEvent>xcopy /y /s "$(SolutionDir)x64\$(ConfigurationName)\Win32Process_CPP.exe" "$(SolutionDir)\UWP\bin\x64\$(ConfigurationName)\AppX\" || xcopy /y /s "$(SolutionDir)$(ConfigurationName)\Win32Process_CPP.exe" "$(SolutionDir)\UWP\bin\x86\$(ConfigurationName)\AppX\"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
when compiling x64 platform of WUP project, post-build tries to copy  "$(SolutionDir)$(ConfigurationName)\Win32Process_CPP.exe" which is generated by x86 platform.